### PR TITLE
chore(fe): AdvocatesProvider & cleanup architecture

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -24,15 +24,23 @@
 
 ## TODOs
 
+### MVP
+
+- [x] Architectuer updates
+  - [x] AdvocatesProvider
 - [ ] Prettify Table
 - [ ] Format Phone Number
-- [ ] Right-size the Years of Experience column (huge header, 2-char data)
-- [ ] Convert Specialties into Tags or something (maybe store a color in the db)
-  - [ ] Specialties Admin Panel
 - Functionality:
   - [ ] Search
   - [ ] Add
   - [ ] Delete
   - [ ] View/Click in to (reuse add?)
+- [ ] Convert client-side search to server-side
+
+### Post-MVP
+
+- [ ] Right-size the Years of Experience column (huge header, 2-char data)
+- [ ] Convert Specialties into Tags or something (maybe store a color in the db)
+  - [ ] Specialties Admin Panel
 - [ ] Bold/Highlight Specialties when it matches the Search Term. i.e. searching for "post-partum" should draw the user's attention to that match in the Specialties column
 - Stub out a "Match me with a Provider" UI

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -13,6 +13,7 @@
 - I'm not versed on Next.js so I'll have to figure out what works. For example, does Context work just the same, which will allow me to split out the data layer into its own unit of responsibility?
   - [This](https://nextjs.org/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) was insightful. Looks like I can just use Context as normal.
 - Kind of want to avoid libraries like MUI/Styled/etc in the interest of time. Nothing here is complex enough to necessitate advanced features from those. Looks like Tailwind can guide most of the styling then bare state manipulation (in an isolated layer) can do most of the rest.
+- Would be great to find a useFetch library. I'm so used to useQuery I'm not sure if there's an idiomatic useFetch library but it would beat useState+useEffect backfill
 
 ## Things I'm unsure about
 

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -44,3 +44,4 @@
   - [ ] Specialties Admin Panel
 - [ ] Bold/Highlight Specialties when it matches the Search Term. i.e. searching for "post-partum" should draw the user's attention to that match in the Specialties column
 - Stub out a "Match me with a Provider" UI
+- [ ] Table Sort (client-side at first, requires non-paginated data)

--- a/src/app/AdvocatesProvider.tsx
+++ b/src/app/AdvocatesProvider.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Advocate } from "@/db/schema";
+import React, {
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type AdvocatesContextType = { advocates: Advocate[] };
+
+const AdvocatesContext = React.createContext<AdvocatesContextType>({
+  advocates: [],
+});
+
+export const AdvocatesProvider = ({ children }: PropsWithChildren) => {
+  const [advocates, setAdvocates] = useState<Advocate[]>([]);
+
+  /** Hydrate advocates (once) */
+  useEffect(() => {
+    (async () => {
+      const response = await fetch("/api/advocates");
+      const json = await response.json();
+      setAdvocates(json.data);
+    })();
+  }, []);
+
+  return (
+    <AdvocatesContext.Provider value={{ advocates }}>
+      {children}
+    </AdvocatesContext.Provider>
+  );
+};
+
+export const useAdvocatesContext = () => useContext(AdvocatesContext);

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,8 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
-
-  const data = advocateData;
+  const data = await db.select().from(advocates);
 
   return Response.json({ data });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { PropsWithChildren } from "react";
+import { AdvocatesProvider } from "./AdvocatesProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -9,14 +11,12 @@ export const metadata: Metadata = {
   description: "Show us what you got",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AdvocatesProvider>{children}</AdvocatesProvider>
+      </body>
     </html>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,16 +9,16 @@ import {
   bigint,
 } from "drizzle-orm/pg-core";
 
-const advocates = pgTable("advocates", {
+export const advocates = pgTable("advocates", {
   id: serial("id").primaryKey(),
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),
   degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
+  specialties: jsonb("payload").default([]).notNull().$type<string[]>(),
   yearsOfExperience: integer("years_of_experience").notNull(),
   phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 
-export { advocates };
+export type Advocate = typeof advocates.$inferSelect;


### PR DESCRIPTION
Cleans up the architecture a bit to split out data into its own layer and clean up some lingering bugs:

- AdvocatesProvider
- Better Typing for the `Advocates` db entity for use as a Type on the frontend
  - :x: Limitations: A better DB type doesn't _necessarily_ imply the Endpoint did a `SELECT *` to load all table columns but we can use it for now.
- direct control over `<input value={search} />` state instead of reinjecting it into the DOM
- other touchups & fixes