### PR TITLE
feat(table): style the table & page; update input UX

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -28,21 +28,23 @@
 
 - [x] Architectuer updates
   - [x] AdvocatesProvider
-- [ ] Prettify Table
-- [ ] Format Phone Number
+- [x] Prettify Table
+- [x] Format Phone Number
 - Functionality:
-  - [ ] Search
-  - [ ] Add
-  - [ ] Delete
-  - [ ] View/Click in to (reuse add?)
+  - [x] Search
 - [ ] Convert client-side search to server-side
 
 ### Post-MVP
 
 - [ ] Right-size the Years of Experience column (huge header, 2-char data)
+  - Wrapping the headers ~helped. Less egregious now.
 - [ ] Convert Specialties into Tags or something (maybe store a color in the db)
   - [ ] Specialties Admin Panel
 - [ ] Bold/Highlight Specialties when it matches the Search Term. i.e. searching for "post-partum" should draw the user's attention to that match in the Specialties column
 - Stub out a "Match me with a Provider" UI
 - [ ] Table Sort (client-side at first, requires non-paginated data)
 - [ ] Responsive design + dynamic Table column widths
+- [ ] Functionality:
+  - [ ] Add
+  - [ ] Delete
+  - [ ] View/Click in to (reuse add?)

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -45,3 +45,4 @@
 - [ ] Bold/Highlight Specialties when it matches the Search Term. i.e. searching for "post-partum" should draw the user's attention to that match in the Specialties column
 - Stub out a "Match me with a Provider" UI
 - [ ] Table Sort (client-side at first, requires non-paginated data)
+- [ ] Responsive design + dynamic Table column widths

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,8 +14,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
-      <body className={inter.className}>
-        <AdvocatesProvider>{children}</AdvocatesProvider>
+      <body
+        className={`antialiased text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-900 ${inter.className}`}
+      >
+        <main style={{ margin: "24px" }}>
+          <AdvocatesProvider>{children}</AdvocatesProvider>
+        </main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,10 @@ export default function Home() {
                 <TableCell>{advocate.degree}</TableCell>
                 <TableCell>
                   {/* TODO: Highlight/Bold a term when it matches SearchTerm */}
-                  <Specialties specialties={advocate.specialties} showMax={3} />
+                  <SpecialtiesList
+                    specialties={advocate.specialties}
+                    showMax={3}
+                  />
                 </TableCell>
                 <TableCell>{advocate.yearsOfExperience}</TableCell>
                 <TableCell>
@@ -120,24 +123,35 @@ const TableCell = ({ children }: PropsWithChildren) => (
   </td>
 );
 
-type SpecialtiesProps = {
+type SpecialtiesListProps = {
   specialties: string[];
   /** Shows up to this many number of specialties. Beyond this number, it renders e.g. `+7 more...` */
   showMax: number;
 };
 
 /** Helps declutter a long list of Specialties by only showing up to showMax of them, then `"+7 more..."` the rest. */
-const Specialties = ({ specialties, showMax }: SpecialtiesProps) => {
-  const specialtiesToRender = specialties.slice(0, showMax);
-  const numHidden = specialties.slice(showMax).length;
-  // TODO: Add accordion/expando so people can reveal the "more"
+const SpecialtiesList = ({ specialties, showMax }: SpecialtiesListProps) => {
+  const [expand, setExpand] = useState(false);
+  const specialtiesToRender = specialties.slice(
+    0,
+    // if the cell is being expanded, show everything.
+    expand ? undefined : showMax
+  );
+  const numHidden = expand ? 0 : specialties.slice(showMax).length;
   // TODO: If one of these matches `searchTerm` then force it to render
   return (
-    <>
+    <div
+      style={{ cursor: "pointer" }}
+      // clickable divs are an a11y issue
+      onClick={() => setExpand((state) => !state)}
+    >
       {specialtiesToRender.map((specialty) => (
         <li key={specialty}>{specialty}</li>
       ))}
-      {numHidden > 0 ? <li> +{numHidden} more...</li> : undefined}
-    </>
+      {numHidden > 0 ? (
+        // yeah we can workshop this
+        <li> +{numHidden} more... (click to see)</li>
+      ) : undefined}
+    </div>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,7 +101,6 @@ export default function Home() {
                     // 2345678910 --> (234) 567-8910
                     .replace(/(\d{3})(\d{3})(\d{4})/, "($1) $2-$3")}
                 </TableCell>
-                {/* input.replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3") */}
               </tr>
             ))}
           </tbody>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { PropsWithChildren, useMemo, useState } from "react";
 import { useAdvocatesContext } from "./AdvocatesProvider";
 
 export default function Home() {
@@ -28,55 +28,116 @@ export default function Home() {
   }, [searchTerm, advocates]);
 
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input
-          style={{ border: "1px solid black" }}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          value={searchTerm}
-        />
-        <button onClick={() => setSearchTerm("")}>Reset Search</button>
+    <>
+      <div className="flex justify-between items-center pb-4">
+        <h1 className="text-3xl">Solace Advocates</h1>
+        <div className="flex">
+          {searchTerm && (
+            <button
+              className="mx-2 px-2 py-1 font-semibold text-sm bg-sky-500 text-white rounded-none shadow-sm text-nowrap rounded-md"
+              onClick={() => setSearchTerm("")}
+            >
+              Reset Search
+            </button>
+          )}
+          <input
+            aria-label="Search"
+            placeholder="Search..."
+            className="block bg-white w-full border border-slate-300 rounded-md p-2 shadow-sm placeholder:italic placeholder:text-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 focus:ring-1 sm:text-sm"
+            onChange={(e) => setSearchTerm(e.target.value)}
+            value={searchTerm}
+          />
+        </div>
       </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => (
-            <tr key={advocate.id}>
-              <td>{advocate.firstName}</td>
-              <td>{advocate.lastName}</td>
-              <td>{advocate.city}</td>
-              <td>{advocate.degree}</td>
-              <td>
-                {/* TODO: Highlight/Bold a term when it matches SearchTerm */}
-                {advocate.specialties.map((s) => (
-                  <div key={s}>{s}</div>
-                ))}
-              </td>
-              <td>{advocate.yearsOfExperience}</td>
-              <td>{advocate.phoneNumber}</td>
+      {searchTerm && filteredAdvocates.length === 0 ? (
+        <>
+          <div>No results to show for "{searchTerm}"...</div>
+          <button
+            // Eh... UI could be better here. Looks a little cheap.
+            className="mx-2 px-2 py-1 font-semibold text-sm bg-sky-500 text-white rounded-none shadow-sm"
+            onClick={() => setSearchTerm("")}
+          >
+            Clear
+          </button>
+        </>
+      ) : (
+        <table className="border-collapse table-auto w-full text-sm rounded-xl">
+          <caption
+            className="caption-top pb-2"
+            // Keep caption in the DOM so the table doesn't jerk "down" when you start searching
+            style={{ visibility: searchTerm ? "visible" : "hidden" }}
+          >
+            Filters applied. Not all advocates may be shown...
+          </caption>
+          <thead className="bg-slate-50 dark:bg-slate-700">
+            <tr>
+              <TableHeader>First Name</TableHeader>
+              <TableHeader>Last Name</TableHeader>
+              <TableHeader>City</TableHeader>
+              <TableHeader>Degree</TableHeader>
+              <TableHeader>Specialties</TableHeader>
+              <TableHeader>Years of Experience</TableHeader>
+              <TableHeader>Phone Number</TableHeader>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </main>
+          </thead>
+          <tbody className="bg-white dark:bg-slate-800">
+            {filteredAdvocates.map((advocate) => (
+              <tr key={advocate.id}>
+                <TableCell>{advocate.firstName}</TableCell>
+                <TableCell>{advocate.lastName}</TableCell>
+                <TableCell>{advocate.city}</TableCell>
+                <TableCell>{advocate.degree}</TableCell>
+                <TableCell>
+                  {/* TODO: Highlight/Bold a term when it matches SearchTerm */}
+                  <Specialties specialties={advocate.specialties} showMax={3} />
+                </TableCell>
+                <TableCell>{advocate.yearsOfExperience}</TableCell>
+                <TableCell>
+                  {advocate.phoneNumber
+                    .toString()
+                    // 2345678910 --> (234) 567-8910
+                    .replace(/(\d{3})(\d{3})(\d{4})/, "($1) $2-$3")}
+                </TableCell>
+                {/* input.replace(/(\d{3})(\d{3})(\d{4})/, "$1-$2-$3") */}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
   );
 }
+
+const TableHeader = ({ children }: PropsWithChildren) => (
+  <th className="border-b dark:border-slate-600 font-medium p-4 pl-8 py-3 text-slate-400 dark:text-slate-200 text-left">
+    {children}
+  </th>
+);
+
+const TableCell = ({ children }: PropsWithChildren) => (
+  <td className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">
+    {children}
+  </td>
+);
+
+type SpecialtiesProps = {
+  specialties: string[];
+  /** Shows up to this many number of specialties. Beyond this number, it renders e.g. `+7 more...` */
+  showMax: number;
+};
+
+/** Helps declutter a long list of Specialties by only showing up to showMax of them, then `"+7 more..."` the rest. */
+const Specialties = ({ specialties, showMax }: SpecialtiesProps) => {
+  const specialtiesToRender = specialties.slice(0, showMax);
+  const numHidden = specialties.slice(showMax).length;
+  // TODO: Add accordion/expando so people can reveal the "more"
+  // TODO: If one of these matches `searchTerm` then force it to render
+  return (
+    <>
+      {specialtiesToRender.map((specialty) => (
+        <li key={specialty}>{specialty}</li>
+      ))}
+      {numHidden > 0 ? <li> +{numHidden} more...</li> : undefined}
+    </>
+  );
+};


### PR DESCRIPTION
Completely reworked the table and page styling:

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/5b4dedaa-0cfd-4cac-898d-be1afdd741e9" />

Admittedly 85% of these styles came from existing Tailwind docs. For example the table styling was ripped straight from [Tailwind's table-layout](https://tailwindcss.com/docs/table-layout) page & DOM. Also the input styling. Most of "my" contributions were Padding, the table header, etc.